### PR TITLE
feat(auth): add OTP-based password reset and improve login token

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,5 +25,8 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"
+  },
+  "prisma": {
+    "schema": "src/prisma/schema.prisma"
   }
 }

--- a/backend/src/config/environtment.config.ts
+++ b/backend/src/config/environtment.config.ts
@@ -14,9 +14,10 @@ export const ENV = {
   // NODE_ENV: process.env.NODE_ENV || 'development',
   DATABASE_URL: requireEnv('DATABASE_URL'),
   DB_SSL: process.env.DB_SSL === 'true',
-  JWT_SECRET: requireEnv('JWT_SECRET'),
   PORT: parseInt(process.env.PORT || '5000', 10),
-
+  JWT_SECRET: requireEnv('JWT_SECRET') as string,
+  JWT_EXPIRED_TIME: requireEnv('JWT_EXPIRED_TIME'),
+  
   // SMTP configs
   SMTP_HOST: 'smtp.gmail.com',
   SMTP_PORT: 465, // cổng đúng cho SMTP Gmail SSL

--- a/backend/src/dao/user.dao.ts
+++ b/backend/src/dao/user.dao.ts
@@ -1,4 +1,5 @@
 import prisma from "../prisma/client.prisma";
+import { randomInt } from 'crypto';
 
 // check if an email input is unique?
 export const checkEmailExists = async(email: string) => {
@@ -36,6 +37,57 @@ export const createUser = async(
   });
 }
 
+// create password reset token
+export const createOTP = async (userId: string) => {
+  const otp = randomInt(100000, 999999).toString();
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 mins
+
+  await prisma.otp_verifications.create({
+    data: {
+      user_id: userId,
+      token: otp,
+      expires_at: expiresAt,
+    },
+  });
+
+  return otp;
+};
+
+// verify
+export const verifyOTP = async (userId: string, token: string) => {
+  const otpRecord = await prisma.otp_verifications.findFirst({
+    where: {
+      user_id: userId,
+      token,
+      expires_at: {
+        gte: new Date(), // greater than or equal to the current date
+      },
+    },
+  });
+
+  return otpRecord;
+};
+// delete after used
+export const deleteOTP = async (otpId: string) => {
+  await prisma.otp_verifications.delete({
+    where: { otp_id: otpId },
+  });
+};
+
+// get user data by id
+export const getUserById = async (userId: string) => {
+  return await prisma.user.findUnique({
+    where: { user_id: userId },
+  });
+};
+
+export const updateNewPassword = async(user_id: string, newHashedPassword: string) => {
+  await prisma.user.update({
+    where: { user_id: user_id},
+    data: { hashed_password: newHashedPassword}
+  });
+};
+
 // create oauth provider
 export const createOAuthProvider = async(
   email: string,
@@ -51,4 +103,4 @@ export const createOAuthProvider = async(
       oauth_id: oauthId,
     },
   });
-}
+};

--- a/backend/src/data/script.sql
+++ b/backend/src/data/script.sql
@@ -17,8 +17,6 @@ CREATE TABLE "user" (
     email VARCHAR(100) UNIQUE NOT NULL,
     phone VARCHAR(20),
     hashed_password TEXT,
-    oauth_provider VARCHAR(50),
-    oauth_id VARCHAR(100),
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
 );
@@ -48,7 +46,6 @@ CREATE TABLE property (
     description TEXT,
     address TEXT,
     ward VARCHAR(100),
-    city VARCHAR(100),
     province VARCHAR(100),
     country VARCHAR(100),
     longitude DECIMAL(9,6),
@@ -154,4 +151,12 @@ CREATE TABLE tax (
     percentage DECIMAL(5,2),
     created_at TIMESTAMP DEFAULT NOW(),
     uploaded_at TIMESTAMP DEFAULT NOW()
+);
+
+-- 15. forgot password otp
+create table otp_verifications (
+	otp_id UUID primary key default uuid_generate_v4(),
+	user_id UUID references "user"(user_id) on delete cascade,
+	token text not null,
+	expires_at timestamp not null
 );

--- a/backend/src/middlewares/auth.middlewares.ts
+++ b/backend/src/middlewares/auth.middlewares.ts
@@ -1,22 +1,40 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
-
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { ENV } from '../config/environtment.config';
 interface AuthRequest extends Request {
   user?: any;
 }
 
-export const authenticateJWT = (req: AuthRequest, res: Response, next: NextFunction) => {
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'Access token missing' });
-  }
-  
-  const token = authHeader.split(' ')[1];
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!);
-    req.user = decoded;
+export const authenticateJWT = (expectedType: string) => {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Access token missing' });
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    try {
+      const decoded = jwt.verify(token, ENV.JWT_SECRET) as JwtPayload;
+
+      if (decoded.type !== expectedType) {
+        return res.status(403).json({ error: `Expected token type '${expectedType}'` });
+      }
+
+      req.user = decoded;
+      next();
+    } catch (err) {
+      return res.status(403).json({ error: 'Invalid or expired token' });
+    }
+  };
+};
+
+export const authorizeRoles = (...allowedRoles: string[]) => {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const user = req.user;
+    if (!user || !allowedRoles.includes(user.role)) {
+      return res.status(403).json({ error: 'Forbidden: insufficient role' });
+    }
     next();
-  } catch (err) {
-    return res.status(403).json({ error: 'Invalid or expired token' });
-  }
+  };
 };

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -133,26 +133,27 @@ model tax {
 }
 
 model user {
-  user_id         String         @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  role_id         Int?
-  name            String         @db.VarChar(100)
-  gender          String?        @db.VarChar(10)
-  dob             DateTime?      @db.Date
-  email           String         @unique @db.VarChar(100)
-  phone           String?        @db.VarChar(20)
-  hashed_password String?
-  created_at      DateTime?      @default(now()) @db.Timestamp(6)
-  updated_at      DateTime?      @default(now()) @db.Timestamp(6)
-  oauth_provider  String?        @db.VarChar(50)
-  oauth_id        String?        @db.VarChar(100)
-  auction         auction[]
-  booking         booking[]
-  payment         payment[]
-  property        property[]
-  role            role?          @relation(fields: [role_id], references: [role_id], onDelete: NoAction, onUpdate: NoAction)
-  userbid         userbid[]
-  userfavorite    userfavorite[]
-  userimage       userimage[]
+  user_id           String              @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  role_id           Int?
+  name              String              @db.VarChar(100)
+  gender            String?             @db.VarChar(10)
+  dob               DateTime?           @db.Date
+  email             String              @unique @db.VarChar(100)
+  phone             String?             @db.VarChar(20)
+  hashed_password   String?
+  created_at        DateTime?           @default(now()) @db.Timestamp(6)
+  updated_at        DateTime?           @default(now()) @db.Timestamp(6)
+  oauth_provider    String?             @db.VarChar(50)
+  oauth_id          String?             @db.VarChar(100)
+  auction           auction[]
+  booking           booking[]
+  otp_verifications otp_verifications[]
+  payment           payment[]
+  property          property[]
+  role              role?               @relation(fields: [role_id], references: [role_id], onDelete: NoAction, onUpdate: NoAction)
+  userbid           userbid[]
+  userfavorite      userfavorite[]
+  userimage         userimage[]
 }
 
 model userbid {
@@ -183,4 +184,12 @@ model userimage {
   image_url   String
   uploaded_at DateTime? @default(now()) @db.Timestamp(6)
   user        user?     @relation(fields: [user_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model otp_verifications {
+  otp_id     String   @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  user_id    String?  @db.Uuid
+  token      String
+  expires_at DateTime @db.Timestamp(6)
+  user       user?    @relation(fields: [user_id], references: [user_id], onDelete: Cascade, onUpdate: NoAction)
 }

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,8 +1,35 @@
 import express from 'express';
-import { signUp } from '../controllers/user.controllers';
+import { 
+  signUp,
+  login,
+  sendOtpToUser,
+  verifyOtpAndGenerateToken,
+  changePassword
+} from '../controllers/user.controllers';
+
+import { authenticateJWT, authorizeRoles } from '../middlewares/auth.middlewares';
 
 const router = express.Router();
 
+export const Roles = {
+  ADMIN: '1',
+  CUSTOMER: '2',
+  PROPERTY_OWNER: '3',
+};
+
+// 1. sign up
 router.post('/signup', signUp);
+// 2. login
+router.post('/login', login);
+// 3. send otp to users
+router.post('/sendotp', sendOtpToUser); 
+// 4. verify otp and generate tokens
+router.post('/verifyotp', verifyOtpAndGenerateToken); 
+// 5. change password
+router.post('/changepw', authenticateJWT('password_reset'), /*authorizeRoles(Roles.ADMIN, Roles.CUSTOMER, Roles.PROPERTY_OWNER),*/ changePassword); 
 
 export default router;
+
+/*
+
+*/

--- a/backend/src/utils/sendEmail.utils.ts
+++ b/backend/src/utils/sendEmail.utils.ts
@@ -1,7 +1,6 @@
 import nodemailer from 'nodemailer';
-import { ENV
-  
- } from '../config/environtment.config';
+import { ENV } from '../config/environtment.config';
+
 export const sendEmail = async (to: string, subject: string, html: string) => {
   const transporter = nodemailer.createTransport({
     host: ENV.SMTP_HOST,
@@ -14,7 +13,7 @@ export const sendEmail = async (to: string, subject: string, html: string) => {
   });
 
   const mailOptions = {
-    from: `"AZStay Support" <${ENV.SMTP_USER}>`,
+    from: `"AZStay Service" <${ENV.SMTP_USER}>`,
     to,
     subject,
     html,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -265,14 +265,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -43,6 +43,7 @@ export default function LoginForm() {
       >
         Login
       </button>
+      
     </form>
   );
 }


### PR DESCRIPTION
- Enhance login to include role and email in JWT payload with 1-hour expiry
- Implement OTP generation, email sending, verification, and deletion for password reset
- Add endpoint to change password after OTP verification with hashed password update
- Fix welcome email to use user name instead of email
- Remove unused OAuth columns from database schema to clean up user table